### PR TITLE
Add reference to ant-contrib to README, path reference to build.xml and guard to build.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ I've modified `vendor/libphonenumber/javascript/build.xml` and turned that into 
 
 The `./build.sh` command uses those two pieces together in order to generate a new version of libphonenumber.js in the `/dist` folder.
 
+Before you run the build script, ensure you have [ant-contrib](http://ant-contrib.sourceforge.net/) installed, then replace `/PATH/TO/ANT-CONTRIB.JAR` with the actual path to your .jar file.
+
 Contributing
 ------------
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ I've modified `vendor/libphonenumber/javascript/build.xml` and turned that into 
 
 The `./build.sh` command uses those two pieces together in order to generate a new version of libphonenumber.js in the `/dist` folder.
 
-Before you run the build script, ensure you have [ant-contrib](http://ant-contrib.sourceforge.net/) installed, then replace `/PATH/TO/ANT-CONTRIB.JAR` with the actual path to your .jar file.
+Before you run the build script, ensure you have [ant-contrib](http://ant-contrib.sourceforge.net/) installed, and present on your system's PATH.
 
 Contributing
 ------------

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-CWD=`pwd`
+`grep -e "/PATH/TO/ANT-CONTRIB.JAR" build.xml 2>&1 1>/dev/null`
+if [ $? -eq 0 ]; then
+  printf "You need to set the path to ant-contrib.jar in build.xml\nChange '/PATH/TO/ANT-CONTRIB.JAR' to match your system path to ant-contrib.jar\n"
+  exit 1
+fi
 
 if [ ! -d "vendor" ]; then
   mkdir vendor

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-`grep -e "/PATH/TO/ANT-CONTRIB.JAR" build.xml 2>&1 1>/dev/null`
-if [ $? -eq 0 ]; then
-  printf "You need to set the path to ant-contrib.jar in build.xml\nChange '/PATH/TO/ANT-CONTRIB.JAR' to match your system path to ant-contrib.jar\n"
-  exit 1
-fi
-
 if [ ! -d "vendor" ]; then
   mkdir vendor
 fi

--- a/build.xml
+++ b/build.xml
@@ -18,7 +18,7 @@
   <taskdef resource="net/sf/antcontrib/antlib.xml"></taskdef>
   <taskdef resource="net/sf/antcontrib/antcontrib.properties">
     <classpath>
-      <pathelement location="/usr/local/Cellar/ant-contrib/1.0b3/share/ant/ant-contrib-1.0b3.jar"/>
+      <pathelement location="/PATH/TO/ANT-CONTRIB.JAR"/>
     </classpath>
   </taskdef>
   <macrodef name="closure-compile">

--- a/build.xml
+++ b/build.xml
@@ -16,11 +16,6 @@
   <property file="${basedir}/tmp/regioncodes.properties" />
 
   <taskdef resource="net/sf/antcontrib/antlib.xml"></taskdef>
-  <taskdef resource="net/sf/antcontrib/antcontrib.properties">
-    <classpath>
-      <pathelement location="/PATH/TO/ANT-CONTRIB.JAR"/>
-    </classpath>
-  </taskdef>
   <macrodef name="closure-compile">
     <attribute name="inputfile" />
     <attribute name="outputfile" />

--- a/build.xml
+++ b/build.xml
@@ -16,6 +16,11 @@
   <property file="${basedir}/tmp/regioncodes.properties" />
 
   <taskdef resource="net/sf/antcontrib/antlib.xml"></taskdef>
+  <taskdef resource="net/sf/antcontrib/antcontrib.properties">
+    <classpath>
+      <pathelement location="/usr/local/Cellar/ant-contrib/1.0b3/share/ant/ant-contrib-1.0b3.jar"/>
+    </classpath>
+  </taskdef>
   <macrodef name="closure-compile">
     <attribute name="inputfile" />
     <attribute name="outputfile" />


### PR DESCRIPTION
This should help for users who don't have ant-contrib installed and don't know what parameters are needed in the build configuration. Let  me know if this works or otherwise?
I had issues cloning the repo and running because I didn't have ant-contrib and wasn't too familiar with ant