### PR TITLE
Modify build scripts to work with Maven for Closure Compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ I've modified `vendor/libphonenumber/javascript/build.xml` and turned that into 
 
 The `./build.sh` command uses those two pieces together in order to generate a new version of libphonenumber.js in the `/dist` folder.
 
-Before you run the build script, ensure you have [ant-contrib](http://ant-contrib.sourceforge.net/) installed, and present on your system's PATH.
+Before you run the build script, ensure you have these tools installed and present on your system's PATH:
+* [Ant](http://ant.apache.org/)
+* [Ant-Contrib](http://ant-contrib.sourceforge.net/)
+* [Maven](http://maven.apache.org/)
 
 Contributing
 ------------

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ do
 done
 
 # Build closure-compiler
-ant -f vendor/closure-compiler/build.xml
+mvn -DskipTests -f vendor/closure-compiler/pom.xml
 
 # Build libphonenumber
 ant -f build.xml compile

--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
   <property name="closure-compiler.dir"
             value="${basedir}/vendor/closure-compiler" />
   <property name="closure-compiler.jar"
-            value="${closure-compiler.dir}/build/compiler.jar" /> 
+            value="${closure-compiler.dir}/target/closure-compiler-1.0-SNAPSHOT.jar" />
   <property name="closure-library.dir"
             value="${basedir}/vendor/closure-library" />
   <property name="closure-linter.dir"


### PR DESCRIPTION
cf. #22
Closure Compiler dropped Ant support: https://github.com/google/closure-compiler/commit/7505969094674f667d9392b5122da2b0cff0be47
